### PR TITLE
add Nextcloud sync support to JupyterLab image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     uidmap \
     slirp4netns \
     fuse-overlayfs \
+    nextcloud-desktop-cmd \ 
   && rm -rf /var/lib/apt/lists/*
 
 # For tools that try to invoke "docker" (e.g., some CWL setups)
@@ -87,5 +88,11 @@ ARG JQ_VERSION=jq-1.8.1
 RUN curl -fsSL \
     "https://github.com/jqlang/jq/releases/download/${JQ_VERSION}/jq-linux-amd64" \
     -o /usr/local/bin/jq && chmod +x /usr/local/bin/jq
+
+COPY nc-sync /usr/local/bin/nc-sync
+RUN chmod 755 /usr/local/bin/nc-sync
+
+COPY jupyter_server_config.py /etc/jupyter/jupyter_server_config.py
+RUN chmod 644 /etc/jupyter/jupyter_server_config.py
 
 USER ${NB_USER}

--- a/jupyter_server_config.py
+++ b/jupyter_server_config.py
@@ -1,0 +1,7 @@
+import os
+c = get_config()
+c.NotebookApp.allow_origin = '*'
+c.NotebookApp.tornado_settings = {
+    'headers': { 'Content-Security-Policy': "frame-ancestors *;" }
+}
+os.system('/usr/local/bin/nc-sync')

--- a/nc-sync
+++ b/nc-sync
@@ -1,0 +1,39 @@
+#!/bin/bash
+rmdir --ignore-fail-on-non-empty /home/jovyan/work
+workdir='/workspace'
+mkdir -p ${workdir}
+server="http://${NEXTCLOUD_HOST:-localhost:8081}"
+json_file="${workdir}/.access_token.json"
+
+function refresh_token {
+  json="$(curl --header "Authorization: token ${JUPYTERHUB_API_TOKEN}" http://${JUPYTER_HOST}/services/refresh-token/tokens)"
+  if [[ -z "${json}" ]]; then
+    token="${NEXTCLOUD_ACCESS_TOKEN}"
+    json="{ \"access_token\": \"${token}\", \"token_expires\": $(date -d "10 min" +%s).0000000 }"
+  fi
+  echo "${json}" > "${json_file}"
+  token=$(jq -r '.access_token' "${json_file}")
+  echo "${token}"
+}
+
+function get_token {
+  if [[ -f "${json_file}" ]]; then
+    now=$(date +%s)
+    token=$(jq -r '.access_token' "${json_file}")
+    expires_at=$(jq -r '.token_expires' "${json_file}"| sed 's/\..*//')
+    if [[ "${expires_at}" -lt ${now} ]]; then
+      token=$(refresh_token)
+    fi
+  else
+    token=$(refresh_token)
+  fi
+  echo "${token}"
+}
+
+function ncsync {
+  while true; do
+    nextcloudcmd -s --user ${JUPYTERHUB_USER} --password $(get_token) --path / "${workdir}" "${server}"
+    sleep 5s
+  done
+}
+ncsync &

--- a/release.yaml
+++ b/release.yaml
@@ -1,4 +1,4 @@
 image_name: iat-jupyterlab
 image_prefix: eoepca
-image_version: 1.3.0
+image_version: 1.3.1
 image_registry: ghcr.io


### PR DESCRIPTION
Adds Nextcloud storage synchronization support to the JupyterLab image.

## Changes
- Add `nextcloud-desktop-cmd` to system packages
- Add `nc-sync` background sync script at `/usr/local/bin/nc-sync`
- Add `jupyter_server_config.py` to launch `nc-sync` at container startup
- Bump image version to 1.3.1